### PR TITLE
Fix chapter 1, and broken Ansible.cfg

### DIFF
--- a/Chapter-01/README.md
+++ b/Chapter-01/README.md
@@ -94,7 +94,7 @@ Create a project directory and `ansible.cfg`
 [ansible@ansible ansible-demo]$ vim ansible.cfg
 
 [ansible@ansible ansible-demo]$ cat ansible.cfg 
-  [Defaults]
+  [defaults]
   inventory = ./hosts 
   remote_user = devops
   ask_pass = false       
@@ -114,7 +114,7 @@ Sample `ansible.cfg` with privilege escaltion details.
 
 ```shell
 [ansible@ansible ansible-demo]$ cat ansible.cfg 
-[Defaults]
+[defaults]
 inventory = ./hosts 
 remote_user = devops
 ask_pass = false       

--- a/Chapter-01/ansible-demo/ansible.cfg
+++ b/Chapter-01/ansible-demo/ansible.cfg
@@ -1,4 +1,4 @@
-[Defaults]  
+[defaults]  
 inventory = ./hosts  
 remote_user = devops  
 ask_pass = false        

--- a/Chapter-01/snippets.md
+++ b/Chapter-01/snippets.md
@@ -109,7 +109,7 @@ libyaml = True
 ## Figure 1.14 - Content of ansible.cfg 
 
 ```
-[Defaults]  
+[defaults]  
 inventory = ./hosts  
 remote_user = devops  
 ask_pass = false
@@ -130,7 +130,7 @@ config file = /home/ansible/ansible-demo/ansible.cfg
 
 ```
 [ansible@ansible ansible-demo]$ cat ansible.cfg  
-[Defaults]  
+[defaults]  
 inventory = ./hosts  
 remote_user = devops  
 ask_pass = false        


### PR DESCRIPTION
This took me awhile to figure out (very new to Ansible), but to those trying to learn from this book, having the example in Chapter 1 broken really throws people for a loop.

The block specifying the inventory file is case sensitive.  So "Defaults" doesn't work, but "defaults" does. 